### PR TITLE
health: Close an inconsequential race condition

### DIFF
--- a/src/health.rs
+++ b/src/health.rs
@@ -108,8 +108,7 @@ pub fn update_health(
         }
     };
 
-    let previous_healthiness = healthiness.load();
-    if previous_healthiness.as_ref() != &result {
+    if **healthiness.load() != result {
         warn!("Backend health change for {}: {}", &server_address, &result);
         healthiness.store(Arc::new(result));
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -108,8 +108,7 @@ pub fn update_health(
         }
     };
 
-    if **healthiness.load() != result {
+    if **healthiness.load() != result && *healthiness.swap(Arc::new(result.clone())) != result {
         warn!("Backend health change for {}: {}", &server_address, &result);
-        healthiness.store(Arc::new(result));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -111,7 +111,7 @@ pub async fn choose_backend(
         .addresses
         .get(&backend)
         .ok_or_else(|| BadBackendError::UnknownHost(backend.clone()))?;
-    if health.load().as_ref() != &Healthiness::Healthy {
+    if **health.load() != Healthiness::Healthy {
         // Backend is down, stall for time?
         Err(BadBackendError::UnhealthyHost(backend))
     } else {


### PR DESCRIPTION
Two racing `update_health` calls could have concurrently made the same change to `healthiness` and printed duplicate log messages.